### PR TITLE
Fixed typo the description of flag worldguard.block-break (build => b…

### DIFF
--- a/src/MihaiChirculete/WorldGuard/WorldGuard.php
+++ b/src/MihaiChirculete/WorldGuard/WorldGuard.php
@@ -475,7 +475,7 @@ class WorldGuard extends PluginBase {
             $permission->addParent("worldguard.break", true);
             PermissionManager::getInstance()->addPermission($permission);
 
-            $permission = new Permission("worldguard.block-break." . $name, "Allows player to build blocks in " . $name . " region.", Permission::DEFAULT_OP);
+            $permission = new Permission("worldguard.block-break." . $name, "Allows player to break blocks in " . $name . " region.", Permission::DEFAULT_OP);
             $permission->addParent("worldguard.block-break", true);
             PermissionManager::getInstance()->addPermission($permission);
 


### PR DESCRIPTION
https://github.com/MihaiChirculete/WorldGuard/blob/a9e130a0eef6c6fb2a63bdbb19111e68857380e9/src/MihaiChirculete/WorldGuard/WorldGuard.php#L466-L480

According to the other flag descriptions, I think `worldguard.block-break` is supposed to be `break` and not `build`