### PR TITLE
php8 changing and fixing regionchange

### DIFF
--- a/src/MihaiChirculete/WorldGuard/WorldGuard.php
+++ b/src/MihaiChirculete/WorldGuard/WorldGuard.php
@@ -262,7 +262,7 @@ class WorldGuard extends PluginBase
         }
     }
 
-    public function onRegionChange(Player $player, string $oldregion, string $newregion)
+    public function onRegionChange(Player $player, ?string $oldregion, ?string $newregion)
     {
         $new = $this->getRegion($newregion);
         $old = $this->getRegion($oldregion);
@@ -282,7 +282,7 @@ class WorldGuard extends PluginBase
                     $this->getLogger()->info("Old Region: " . $old->getName());
                 }
             }
-            if ($old !== "") {
+            if ($old !== null && $old !== "") {
                 if ($old->getFlag("console-cmd-on-leave") !== "none") {
                     $cmd = str_replace("%player%", $player->getName(), $old->getFlag("console-cmd-on-leave"));
                     $player->getServer()->dispatchCommand(new ConsoleCommandSender(Server::getInstance(), Server::getInstance()->getLanguage()), $cmd);
@@ -307,7 +307,7 @@ class WorldGuard extends PluginBase
                 }
             }
 
-            if ($new !== "") {
+            if ($new !== null && $new !== "") {
                 if ($new->getFlag("console-cmd-on-enter") !== "none") {
                     $cmd = str_replace("%player%", $player->getName(), $new->getFlag("console-cmd-on-enter"));
                     $player->getServer()->dispatchCommand(new ConsoleCommandSender(Server::getInstance(), Server::getInstance()->getLanguage()), $cmd);

--- a/src/MihaiChirculete/WorldGuard/WorldGuard.php
+++ b/src/MihaiChirculete/WorldGuard/WorldGuard.php
@@ -376,19 +376,19 @@ class WorldGuard extends PluginBase
                     }
                 }
 
-                if ($new != null && ! empty($new)) {
+                if ($new !== null && $new !== "") {
                     $newRegionEffects = $new->getEffects();
                 } else {
                     $newRegionEffects = null;
                 }
-                if ($old != null && ! empty($old)) {
+                if ($old !== null && $old !== "") {
                     $oldRegionEffects = $old->getEffects();
                 } else {
                     $oldRegionEffects = null;
                 }
                 
                 // Iterate all old effects and remove them
-                if (! empty($oldRegionEffects) && $oldRegionEffects != null) {
+                if ($oldRegionEffects != null && $oldRegionEffects != "") {
                     if ($this->resourceManager->getConfig()["debugging"] === true) {
                         $this->getLogger()->info("Removing region-given effects, and re-adding any effects the player had.");
                     }
@@ -398,7 +398,7 @@ class WorldGuard extends PluginBase
                 }
 
                 // Iterate all new effects and add them
-                if (! empty($newRegionEffects) && $newRegionEffects != null) {
+                if ($newRegionEffects != null && $newRegionEffects != "") {
                     if ($this->resourceManager->getConfig()["debugging"] === true) {
                         $this->getLogger()->info("Saving the player's current effects that the region overwrites, and giving the new effects from the region.");
                     }


### PR DESCRIPTION
https://www.php.net/manual/en/migration71.new-features.php

 ...because promoted parameters imply a property declaration, nullability must be explicitly declared, and is not inferred from a null default value:
https://wiki.php.net/rfc/constructor_promotion